### PR TITLE
Added configuration file for paths to eyaml keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # ansible-filter-eyaml
 Ansible filter plugin to de-crypt eyaml encrypted variables
 
-The typical approach to encrypting secrets with Ansible is to use ansible-vault or alternatively a third party encryption tool such as git-crypt. The problem with both of these methods is that they perform full file encryption thus turning your inventory and variable files into binary blobs. This makes it difficult to navigate and version your inventory facts within your chosen revision control system. 
+The typical approach to encrypting secrets with Ansible is to use ansible-vault or alternatively a third party encryption tool such as git-crypt. The problem with both of these methods is that they perform full file encryption thus turning your inventory and variable files into binary blobs. This makes it difficult to navigate and version your inventory facts within your chosen revision control system.
 
-[Heira-eyaml] ( https://github.com/TomPoulton/hiera-eyaml ) is a backend for the puppet hiera key/value store. It provides per-value / in-line encryption of sensitive data within yaml files. This jinja2 filter_plugin provides support for eyaml de-cryption in ansible.
+[Hiera-eyaml] ( https://github.com/TomPoulton/hiera-eyaml ) is a backend for the puppet hiera key/value store. It provides per-value / in-line encryption of sensitive data within yaml files. This jinja2 filter_plugin provides support for eyaml de-cryption in ansible.
 
-Given the following yaml file: 
+Given the following yaml file:
 
 ```
 ---
@@ -21,9 +21,9 @@ secret_variable: >
     XRZxbzA8BgkqhkiG9w0BBwEwHQYJYIZIAWUDBAEqBBC4VCBEfwwPn33Rbd0t
 ```
 
-The in-line encrypted variable can be referenced and automaticly de-crypted within your ansible plays/roles using the following Jinja2 instantiation {{ secret_variable | eyaml }}. 
+The in-line encrypted variable can be referenced and automaticly de-crypted within your ansible plays/roles using the following Jinja2 instantiation {{ secret_variable | eyaml }}.
 
-Obvioulsy it depends on a working installation of heira-eyaml being avaialble.
+Obvioulsy it depends on a working installation of hiera-eyaml being avaialble.
 
 To produce encrypted variables for inclusion in your inventory you can use the eyaml command line tool:
 

--- a/README.md
+++ b/README.md
@@ -25,6 +25,8 @@ The in-line encrypted variable can be referenced and automaticly de-crypted with
 
 Obvioulsy it depends on a working installation of hiera-eyaml being avaialble.
 
+The script expects a file named "eyaml.yml" next to itself, in which the paths to the private and public key used for (en|de)cryption. (An example is provided in this repository)
+
 To produce encrypted variables for inclusion in your inventory you can use the eyaml command line tool:
 
 ```

--- a/eyaml.py
+++ b/eyaml.py
@@ -1,13 +1,23 @@
+# usage
+## The in-line encrypted variable can be referenced and automaticly de-crypted within your ansible plays/roles using the following Jinja2 instantiation {{ secret_variable | eyaml }}.
 import os
 import subprocess
 import sys
+import yaml
 
 def eyaml(arg):
-    FNULL = open(os.devnull, 'w')
-    cmd="eyaml decrypt -s \"" + arg + "\""
-    output = subprocess.check_output(cmd, stderr=FNULL, shell=True)
-    return output.rstrip();
+  path_to_script = os.path.dirname(os.path.realpath(__file__))
+  with open(path_to_script + "/eyaml.yml", 'r') as ymlfile:
+    cfg = yaml.load(ymlfile)
+
+    eyaml_private_key=cfg['eyaml_private_key']
+    eyaml_public_key=cfg['eyaml_public_key']
+
+  FNULL = open(os.devnull, 'w')
+  cmd="eyaml decrypt --pkcs7-private-key=" + eyaml_private_key + " --pkcs7-public-key=" + eyaml_public_key + " -s \"" + arg + "\""
+  output = subprocess.check_output(cmd, stderr=FNULL, shell=True)
+  return output.rstrip();
 
 class FilterModule(object):
-     def filters(self):
-         return {'eyaml': eyaml}
+   def filters(self):
+       return {'eyaml': eyaml}

--- a/eyaml.yml
+++ b/eyaml.yml
@@ -1,0 +1,3 @@
+---
+eyaml_private_key: /etc/eyaml_keys/private_key.pkcs7.pem
+eyaml_public_key: /etc/eyaml_keys/public_key.pkcs7.pem


### PR DESCRIPTION
Hi,

as the title states I modified the script to expect a configuration next to itself.

The configuration file shall be YAML formatted an contain two parameters:
* one pointing to the private key file
* and a second pointing to the public key file

Gives the user the chance to store these wherever they want.

On a side note: I fixed two typos in README, which stated "heira" instead of "hiera"

Regards and thanks for the script!